### PR TITLE
feat: implement consent and non-therapy disclaimer screen

### DIFF
--- a/care-campus-dashboard/app/chat/page.tsx
+++ b/care-campus-dashboard/app/chat/page.tsx
@@ -1,16 +1,28 @@
-// Chat Page
+'use client';
 
-export default function ChatPage() {
-    return (
-        <div className="min-h-screen bg-zinc-50 dark:bg-black flex flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
-            <div className="max-w-3xl mx-auto text-center">
-                <h1 className="text-4xl font-bold text-black dark:text-zinc-50 mb-4">
-                    Chat with Terry the Terp
-                </h1>
-                <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-8">
-                    This feature is coming soon! Stay tuned for updates.
-                </p>
-            </div>
-        </div>
-    );
+import ProtectedRoute from '@/app/components/ProtectedRoute';
+
+function ChatContent() {
+  // Your existing chat page code goes here
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold text-black dark:text-zinc-50 mb-4">
+          Chat with Terry the Terp
+        </h1>
+        <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-8">
+          Your AI mental health companion
+        </p>
+        {/* Add your chat interface here */}
+      </div>
+    </div>
+  );
+}
+
+export default function Chat() {
+  return (
+    <ProtectedRoute>
+      <ChatContent />
+    </ProtectedRoute>
+  );
 }

--- a/care-campus-dashboard/app/components/ConsentScreen.tsx
+++ b/care-campus-dashboard/app/components/ConsentScreen.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ConsentScreenProps {
+  onAccept: () => void;
+}
+
+export default function ConsentScreen({ onAccept }: ConsentScreenProps) {
+  const [accepted, setAccepted] = useState(false);
+
+  const handleAccept = () => {
+    if (accepted) {
+      // Store consent in localStorage
+      const consentData = {
+        accepted: true,
+        timestamp: new Date().toISOString(),
+        version: '1.0' // Track consent version for future updates
+      };
+      localStorage.setItem('care_campus_consent', JSON.stringify(consentData));
+      onAccept();
+    }
+  };
+
+  const handleDecline = () => {
+    // Redirect to declined page with resources
+    window.location.href = '/declined';
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl w-full">
+        <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-xl p-8 md:p-12">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <h1 className="text-3xl md:text-4xl font-bold text-black dark:text-zinc-50 mb-4">
+              Welcome to Care Campus
+            </h1>
+            <p className="text-lg text-zinc-600 dark:text-zinc-400">
+              Before you continue, please read and accept our terms
+            </p>
+          </div>
+
+          {/* Disclaimer Content */}
+          <div className="mb-8 space-y-6 max-h-96 overflow-y-auto p-6 bg-zinc-50 dark:bg-zinc-800 rounded-lg border-2 border-zinc-200 dark:border-zinc-700">
+            <section>
+              <h2 className="text-xl font-semibold text-black dark:text-zinc-50 mb-3">
+                Non-Therapy Disclaimer
+              </h2>
+              <p className="text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                Care Campus is an educational and support resource platform. <strong>This is not therapy or professional mental health treatment.</strong> The content provided, including interactions with Terry the Terp (our AI chatbot), learning modules, and resources, are for informational and educational purposes only.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-black dark:text-zinc-50 mb-3">
+                Important Information
+              </h2>
+              <ul className="list-disc list-inside space-y-2 text-zinc-700 dark:text-zinc-300">
+                <li>This platform does not replace professional mental health services</li>
+                <li>Our AI chatbot is not a licensed therapist or counselor</li>
+                <li>Information provided should not be used for diagnosing or treating mental health conditions</li>
+                <li>We do not provide emergency or crisis intervention services</li>
+                <li>Your responses and interactions may be stored for improving our services</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-black dark:text-zinc-50 mb-3">
+                When to Seek Professional Help
+              </h2>
+              <p className="text-zinc-700 dark:text-zinc-300 leading-relaxed mb-4">
+                If you are experiencing a mental health crisis, please contact a professional immediately. We encourage you to speak with a licensed mental health professional, counselor, or therapist for personalized care.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-black dark:text-zinc-50 mb-3">
+                Your Consent
+              </h2>
+              <p className="text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                By continuing, you acknowledge that you have read and understood this disclaimer. You agree that Care Campus is an educational resource and not a substitute for professional mental health care.
+              </p>
+            </section>
+          </div>
+
+          {/* Crisis Resources */}
+          <div className="mb-8 p-6 bg-red-50 dark:bg-red-900/20 border-2 border-red-300 dark:border-red-800 rounded-lg">
+            <h2 className="text-xl font-semibold text-red-900 dark:text-red-200 mb-4 flex items-center">
+              <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              Crisis Resources
+            </h2>
+            <div className="space-y-3 text-zinc-800 dark:text-zinc-200">
+              <div>
+                <p className="font-semibold">If you're in crisis or need immediate help:</p>
+              </div>
+              <div className="space-y-2 ml-4">
+                <p>
+                  <strong>988 Suicide & Crisis Lifeline:</strong>{' '}
+                  <a href="tel:988" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Call or text 988
+                  </a>
+                </p>
+                <p>
+                  <strong>Crisis Text Line:</strong>{' '}
+                  <a href="sms:741741" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Text HOME to 741741
+                  </a>
+                </p>
+                <p>
+                  <strong>Emergency Services:</strong>{' '}
+                  <a href="tel:911" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Call 911
+                  </a>
+                </p>
+                <p>
+                  <strong>Campus Counseling:</strong>{' '}
+                  <span className="text-zinc-700 dark:text-zinc-300">
+                    Contact your university's counseling center
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Consent Checkbox */}
+          <div className="mb-8">
+            <label className="flex items-start cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={accepted}
+                onChange={(e) => setAccepted(e.target.checked)}
+                className="mt-1 h-5 w-5 rounded border-zinc-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+              />
+              <span className="ml-3 text-zinc-700 dark:text-zinc-300 group-hover:text-black dark:group-hover:text-zinc-50 transition-colors">
+                I have read and understood the disclaimer above. I acknowledge that Care Campus is not a substitute for professional mental health care, and I agree to use this platform for educational purposes only.
+              </span>
+            </label>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex flex-col sm:flex-row gap-4">
+            <button
+              onClick={handleAccept}
+              disabled={!accepted}
+              className={`flex-1 px-6 py-3 rounded-lg font-semibold transition-colors ${
+                accepted
+                  ? 'bg-blue-500 hover:bg-blue-600 text-white cursor-pointer'
+                  : 'bg-zinc-300 dark:bg-zinc-700 text-zinc-500 dark:text-zinc-500 cursor-not-allowed'
+              }`}
+            >
+              Accept and Continue
+            </button>
+            <button
+              onClick={handleDecline}
+              className="flex-1 px-6 py-3 bg-zinc-200 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 rounded-lg hover:bg-zinc-300 dark:hover:bg-zinc-700 font-semibold transition-colors"
+            >
+              Decline
+            </button>
+          </div>
+
+          {/* Footer Note */}
+          <p className="mt-6 text-sm text-center text-zinc-500 dark:text-zinc-500">
+            You can review this information anytime in the Resources section
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/care-campus-dashboard/app/components/ProtectedRoute.tsx
+++ b/care-campus-dashboard/app/components/ProtectedRoute.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { hasUserConsent } from '@/app/utils/consent';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const router = useRouter();
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkConsent = () => {
+      const hasConsent = hasUserConsent();
+      
+      if (!hasConsent) {
+        // Redirect to home page which will show consent screen
+        router.push('/');
+      } else {
+        setIsAuthorized(true);
+      }
+    };
+
+    checkConsent();
+  }, [router]);
+
+  // Show loading state while checking
+  if (isAuthorized === null) {
+    return (
+      <div className="min-h-screen bg-zinc-50 dark:bg-black flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p className="text-zinc-600 dark:text-zinc-400">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Only render children if authorized
+  return isAuthorized ? <>{children}</> : null;
+}

--- a/care-campus-dashboard/app/declined/page.tsx
+++ b/care-campus-dashboard/app/declined/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function DeclinedPage() {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-2xl w-full text-center">
+        <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-xl p-8 md:p-12">
+          <div className="mb-6">
+            <div className="mx-auto w-16 h-16 bg-zinc-200 dark:bg-zinc-700 rounded-full flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-zinc-600 dark:text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+          </div>
+
+          <h1 className="text-3xl font-bold text-black dark:text-zinc-50 mb-4">
+            Thank You for Visiting
+          </h1>
+          <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-6">
+            You must accept the terms and disclaimer to use Care Campus. If you have concerns about our terms, please contact us or review them again.
+          </p>
+          
+          <div className="mb-8 p-6 bg-blue-50 dark:bg-blue-900/20 border-2 border-blue-300 dark:border-blue-800 rounded-lg">
+            <h2 className="text-xl font-semibold text-blue-900 dark:text-blue-200 mb-4">
+              Mental Health Resources
+            </h2>
+            <div className="space-y-3 text-left">
+              <p className="text-zinc-700 dark:text-zinc-300">
+                If you need mental health support, here are some resources available to you:
+              </p>
+              <ul className="space-y-2 ml-4">
+                <li>
+                  <strong className="text-zinc-800 dark:text-zinc-200">988 Suicide & Crisis Lifeline:</strong>{' '}
+                  <a href="tel:988" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Call or text 988
+                  </a>
+                </li>
+                <li>
+                  <strong className="text-zinc-800 dark:text-zinc-200">Crisis Text Line:</strong>{' '}
+                  <a href="sms:741741" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Text HOME to 741741
+                  </a>
+                </li>
+                <li>
+                  <strong className="text-zinc-800 dark:text-zinc-200">Emergency Services:</strong>{' '}
+                  <a href="tel:911" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    Call 911
+                  </a>
+                </li>
+                <li>
+                  <strong className="text-zinc-800 dark:text-zinc-200">SAMHSA National Helpline:</strong>{' '}
+                  <a href="tel:1-800-662-4357" className="text-blue-600 dark:text-blue-400 hover:underline font-semibold">
+                    1-800-662-4357
+                  </a>
+                </li>
+                <li>
+                  <strong className="text-zinc-800 dark:text-zinc-200">Campus Counseling:</strong>{' '}
+                  <span className="text-zinc-700 dark:text-zinc-300">
+                    Contact your university's counseling center
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <button
+              onClick={() => router.push('/')}
+              className="w-full px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-semibold"
+            >
+              Review Terms Again
+            </button>
+            <p className="text-sm text-zinc-500 dark:text-zinc-500">
+              Questions? Contact us at support@carecampus.edu
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/care-campus-dashboard/app/layout.tsx
+++ b/care-campus-dashboard/app/layout.tsx
@@ -28,6 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         <header className="w-full bg-transparent">
           <div className="max-w-6xl mx-auto px-4 py-3">

--- a/care-campus-dashboard/app/learn/[lessonName]/page.tsx
+++ b/care-campus-dashboard/app/learn/[lessonName]/page.tsx
@@ -3,13 +3,14 @@
 import { useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import modules from '@/assets/sample_modules.json';
+import ProtectedRoute from '@/app/components/ProtectedRoute';
 
 interface Lesson {
   lesson_title: string;
   questions: string[];
 }
 
-export default function LessonPage() {
+function LessonContent() {
   const router = useRouter();
   const params = useParams();
   const lessonName = decodeURIComponent(params.lessonName as string);
@@ -116,5 +117,13 @@ export default function LessonPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LessonPage() {
+  return (
+    <ProtectedRoute>
+      <LessonContent />
+    </ProtectedRoute>
   );
 }

--- a/care-campus-dashboard/app/learn/complete/page.tsx
+++ b/care-campus-dashboard/app/learn/complete/page.tsx
@@ -1,29 +1,65 @@
 'use client';
 
-// import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import modules from '@/assets/sample_modules.json';
+import ProtectedRoute from '@/app/components/ProtectedRoute';
 
-export default function LessonCompletePage() {
+function LessonCompleteContent() {
   const router = useRouter();
 
-    // Format a congratulatory message with a "Back to Learn" button
-    return (
-      <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-3xl mx-auto">
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto text-center">
+        <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-12">
+          {/* Success Icon */}
+          <div className="mx-auto w-20 h-20 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-6">
+            <svg 
+              className="w-12 h-12 text-green-600 dark:text-green-400" 
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24"
+            >
+              <path 
+                strokeLinecap="round" 
+                strokeLinejoin="round" 
+                strokeWidth={2} 
+                d="M5 13l4 4L19 7" 
+              />
+            </svg>
+          </div>
+
           <h1 className="text-4xl font-bold text-black dark:text-zinc-50 mb-4">
-            Lesson Complete
+            Lesson Complete! 🎉
           </h1>
           <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-8">
-            Congratulations! You have completed the lesson.
+            Congratulations! You have successfully completed the lesson. Keep up the great work on your mental health journey.
           </p>
-          <button
-            onClick={() => router.push('/learn')}
-            className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-medium"
-          >
-            Back to Learn
-          </button>
+
+          <div className="space-y-4">
+            <button
+              onClick={() => router.push('/learn')}
+              className="w-full sm:w-auto px-8 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-semibold"
+            >
+              Back to Learn
+            </button>
+            <div>
+              <button
+                onClick={() => router.push('/')}
+                className="text-blue-600 dark:text-blue-400 hover:underline text-sm"
+              >
+                Go to Dashboard
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-    );
+    </div>
+  );
+}
+
+export default function LessonCompletePage() {
+  return (
+    <ProtectedRoute>
+      <LessonCompleteContent />
+    </ProtectedRoute>
+  );
 }

--- a/care-campus-dashboard/app/learn/page.tsx
+++ b/care-campus-dashboard/app/learn/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import modules from '@/assets/sample_modules.json';
+import ProtectedRoute from '@/app/components/ProtectedRoute';
 
 interface Lesson {
   lesson_title: string;
@@ -14,7 +15,7 @@ interface Module {
   lessons: Lesson[];
 }
 
-export default function Learn() {
+function LearnContent() {
   const router = useRouter();
   const [selectedModule, setSelectedModule] = useState<Module | null>(null);
 
@@ -83,14 +84,20 @@ export default function Learn() {
                   > 
                     Complete Questions 
                   </button>
-
                 </div>
-                
               ))}
             </div>
           </div>
         )}
       </div>
     </div>
+  );
+}
+
+export default function Learn() {
+  return (
+    <ProtectedRoute>
+      <LearnContent />
+    </ProtectedRoute>
   );
 }

--- a/care-campus-dashboard/app/page.tsx
+++ b/care-campus-dashboard/app/page.tsx
@@ -1,16 +1,52 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import Image from "next/image";
 import { useRouter } from 'next/navigation';
+import ConsentScreen from '@/app/components/ConsentScreen';
 
 export default function Home() {
   const router = useRouter();
-  /** Simple homepage with a welcome message(Welcome to the Care Campus Dashboard) 
-   * and an image representing mental health logo(XFoundry Logo.jpeg from public folder)
-   * Include a brief description of the app's purpose and navigation buttons to access different features.
-   * Buttons will include "Go to Learn", "View Resources", and "Chat with Terry the Terp".
-  */
+  const [hasConsent, setHasConsent] = useState<boolean | null>(null);
 
+  useEffect(() => {
+    // Check if user has already given consent
+    const consentData = localStorage.getItem('care_campus_consent');
+    if (consentData) {
+      try {
+        const parsed = JSON.parse(consentData);
+        setHasConsent(parsed.accepted === true);
+      } catch (error) {
+        console.error('Error parsing consent data:', error);
+        setHasConsent(false);
+      }
+    } else {
+      setHasConsent(false);
+    }
+  }, []);
+
+  const handleConsentAccepted = () => {
+    setHasConsent(true);
+  };
+
+  // Show loading state while checking consent
+  if (hasConsent === null) {
+    return (
+      <div className="min-h-screen bg-zinc-50 dark:bg-black flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p className="text-zinc-600 dark:text-zinc-400">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show consent screen if user hasn't accepted
+  if (!hasConsent) {
+    return <ConsentScreen onAccept={handleConsentAccepted} />;
+  }
+
+  // Show main dashboard if consent is given
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black flex flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-3xl mx-auto text-center">
@@ -50,5 +86,4 @@ export default function Home() {
       </div>
     </div>
   );
-
 }

--- a/care-campus-dashboard/app/resources/page.tsx
+++ b/care-campus-dashboard/app/resources/page.tsx
@@ -3,7 +3,9 @@
  * Renders resources from `assets/resources.json`.
  * The JSON is structured as an object with sections (e.g. "Crisis_Resources").
  */
+'use client';
 
+import ProtectedRoute from '@/app/components/ProtectedRoute';
 import resources from '@/assets/resources.json';
 
 function humanizeKey(key: string) {
@@ -12,7 +14,7 @@ function humanizeKey(key: string) {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-export default function ResourcesPage() {
+function ResourcesContent() {
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
@@ -44,5 +46,13 @@ export default function ResourcesPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function ResourcesPage() {
+  return (
+    <ProtectedRoute>
+      <ResourcesContent />
+    </ProtectedRoute>
   );
 }

--- a/care-campus-dashboard/app/utils/consent.ts
+++ b/care-campus-dashboard/app/utils/consent.ts
@@ -1,0 +1,101 @@
+// utils/consent.ts
+
+export interface ConsentData {
+  accepted: boolean;
+  timestamp: string;
+  version: string;
+}
+
+const CONSENT_STORAGE_KEY = 'care_campus_consent';
+const CURRENT_CONSENT_VERSION = '1.0';
+
+/**
+ * Check if user has given consent
+ */
+export function hasUserConsent(): boolean {
+  if (typeof window === 'undefined') return false;
+  
+  try {
+    const consentData = localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!consentData) return false;
+    
+    const parsed: ConsentData = JSON.parse(consentData);
+    return parsed.accepted === true && parsed.version === CURRENT_CONSENT_VERSION;
+  } catch (error) {
+    console.error('Error checking consent:', error);
+    return false;
+  }
+}
+
+/**
+ * Store user consent
+ */
+export function storeConsent(): void {
+  if (typeof window === 'undefined') return;
+  
+  const consentData: ConsentData = {
+    accepted: true,
+    timestamp: new Date().toISOString(),
+    version: CURRENT_CONSENT_VERSION
+  };
+  
+  localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(consentData));
+}
+
+/**
+ * Clear user consent (for testing or revocation)
+ */
+export function clearConsent(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(CONSENT_STORAGE_KEY);
+}
+
+/**
+ * Get consent data
+ */
+export function getConsentData(): ConsentData | null {
+  if (typeof window === 'undefined') return null;
+  
+  try {
+    const consentData = localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!consentData) return null;
+    return JSON.parse(consentData);
+  } catch (error) {
+    console.error('Error getting consent data:', error);
+    return null;
+  }
+}
+
+/**
+ * Crisis resources data
+ */
+export const CRISIS_RESOURCES = [
+  {
+    name: '988 Suicide & Crisis Lifeline',
+    contact: '988',
+    type: 'call_text',
+    description: 'Call or text 988 for immediate crisis support',
+    link: 'tel:988'
+  },
+  {
+    name: 'Crisis Text Line',
+    contact: 'Text HOME to 741741',
+    type: 'text',
+    description: 'Text-based crisis support',
+    link: 'sms:741741'
+  },
+  {
+    name: 'Emergency Services',
+    contact: '911',
+    type: 'call',
+    description: 'For immediate life-threatening emergencies',
+    link: 'tel:911'
+  },
+  {
+    name: 'SAMHSA National Helpline',
+    contact: '1-800-662-4357',
+    type: 'call',
+    description: 'Substance abuse and mental health services',
+    link: 'tel:1-800-662-4357'
+  }
+];


### PR DESCRIPTION
- Add ConsentScreen component with terms and disclaimer
- Display crisis resources prominently on consent screen
- Store consent acceptance in localStorage with timestamp and version
- Implement ProtectedRoute wrapper for all feature pages
- Protect /learn, /chat, /resources routes from unauthorized access
- Add /declined page with crisis resources for users who decline
- Create consent utility functions for reusable consent logic
- Fix hydration warning caused by browser extensions
- Add crisis resource constants for app-wide use

Closes #5 